### PR TITLE
Added test folders, updated import path on util/persistence 

### DIFF
--- a/src/tso/importer/tests/test_importer.py
+++ b/src/tso/importer/tests/test_importer.py
@@ -1,0 +1,8 @@
+import pytest
+from tso.importer import data_importer
+
+class TestImporter():
+
+    def test_data_importer(self):
+        temp =1
+        assert 1 == 1

--- a/src/tso/observation/tests/test_observation.py
+++ b/src/tso/observation/tests/test_observation.py
@@ -1,0 +1,7 @@
+import pytest
+from tso.observation import observation_request
+class TestObservation():
+
+    def test_observation_request(self):
+        temp =1
+        assert 1 == 1

--- a/src/tso/scheduler/constraint_aggregator.py
+++ b/src/tso/scheduler/constraint_aggregator.py
@@ -4,7 +4,7 @@ constraint_aggregator.py
 Aggregated Constraints from Astroplan as well as our own user-defined constraints.
 """
 
-from astroplan.constraint import AtNightConstraint, AirmassConstraint
+from astroplan.constraints import AtNightConstraint, AirmassConstraint
 
 
 def initialize_constraints():

--- a/src/tso/scheduler/scheduler.py
+++ b/src/tso/scheduler/scheduler.py
@@ -5,9 +5,9 @@ from tso.importer import data_importer as di
 from tso.scheduler import constraint_aggregator as ca
 from tso.scheduler import transitioner
 
-    def generate_schedule(self, schedule_horizon):
-        print(schedule_horizon)
-        self.block_count += 1
+def generate_schedule(self, schedule_horizon):
+    print(schedule_horizon)
+    self.block_count += 1
 
 
 

--- a/src/tso/util/persistence.py
+++ b/src/tso/util/persistence.py
@@ -5,7 +5,7 @@ We will be primarily be interfacing with a mySQL DB.
 """
 
 import mysql.connector
-from src.configuration import configuration_parser
+from configuration import configuration_parser
 
 config = configuration_parser.get_database_config()
 


### PR DESCRIPTION
Added start of tests for observation and data_importer.

**Import path updated on util/persistance.
- When running pytest from within src import of configuration parser in src/tso/util/persistence.py was not reachable. 
original:
from src.configuration import configuration_parser
updated: 
from configuration import configuration_parser