### PR TITLE
New tests for observation and dataImporter + fix for the fixed_target() within obsevation_request

### DIFF
--- a/src/tso/importer/tests/test_importer.py
+++ b/src/tso/importer/tests/test_importer.py
@@ -1,5 +1,6 @@
 from tso.importer import data_importer
 from sys import maxsize as MAX_SIZE
+from tso.observation.cfht_observation_block import CFHTObservationBlock
 
 
 class TestDataImporter:

--- a/src/tso/importer/tests/test_transformer.py
+++ b/src/tso/importer/tests/test_transformer.py
@@ -1,0 +1,25 @@
+from tso.importer import transformer
+from tso.importer import data_importer
+from tso.observation import observation_request
+from sys import maxsize as MAX_SIZE
+
+
+class TestTransformer:
+
+    def test_transformer_validate_block(self):
+        observations = data_importer.get_all_observations()
+        for o in observations:
+            assert transformer.validate_block(o) == True
+
+
+    def test_transformer_block_to_request(self):
+        observations = data_importer.get_all_observations()
+        for o in observations:
+            request =transformer.block_to_request(o)
+            assert isinstance(request, observation_request.ObservationRequest)
+
+    def test_transformer_transform_cfht_observing_block(self):
+        cfhtObservations = data_importer.get_all_observations()
+        requests = transformer.transform_cfht_observing_blocks(cfhtObservations)
+        for r in requests:
+            assert isinstance(r, observation_request.ObservationRequest)

--- a/src/tso/observation/observation_request.py
+++ b/src/tso/observation/observation_request.py
@@ -16,15 +16,12 @@ class ObservationRequest:
         self.observation_duration = observation_duration
 
     def get_target(self):
-        ra = self.coordinates[0]*u.deg
-        dec = self.coordinates[1]*u.deg
-        skycoord = SkyCoord(ra=ra, dec=dec, frame='icrs')
-        target = FixedTarget(skycoord, str(self.observation_id))
+        target = FixedTarget(coord=self.coordinates, name=str(self.observation_id))
         return target
 
     def __str__(self):
         return str(self.observation_id) + " " + \
-               str(self.coordinates[0]) + " " + \
-               str(self.coordinates[1]) + " " + \
+               str(self.coordinates.ra.degree) + " " + \
+               str(self.coordinates.dec.degree) + " " + \
                str(self.agency_id) + " " +\
                str(self.priority)

--- a/src/tso/observation/tests/test_observation.py
+++ b/src/tso/observation/tests/test_observation.py
@@ -1,7 +1,0 @@
-import pytest
-from tso.observation import observation_request
-class TestObservation():
-
-    def test_observation_request(self):
-        temp =1
-        assert 1 == 1

--- a/src/tso/observation/tests/test_observation_request.py
+++ b/src/tso/observation/tests/test_observation_request.py
@@ -1,0 +1,64 @@
+import pytest
+import astroplan
+from tso.observation import observation_request
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astroplan import FixedTarget
+
+
+@pytest.fixture(scope="module")
+def req():
+    c = SkyCoord(ra=10.625*u.degree, dec=41.2*u.degree, frame='icrs')
+    observation_id = 69
+    coordinates = c
+    agency_id = 2
+    priority = 8
+    remaining_observing_chances = 3
+    observation_duration = 6000
+    req = observation_request.ObservationRequest(observation_id, coordinates,\
+        agency_id,priority, remaining_observing_chances, observation_duration)
+    return req
+
+class TestObservationRequest():
+    def test_dummy_test(self):
+        # Shows the limitsof a SkyCoord
+        # a) declination < -90
+        with pytest.raises(ValueError):
+            c = SkyCoord(ra=90.625*u.degree, dec=-90.1*u.degree, frame='icrs')
+
+        # b) declination > 90
+        with pytest.raises(ValueError):
+            c = SkyCoord(ra=90.625*u.degree, dec=90.1*u.degree, frame='icrs')
+
+        #  c) ra above 360
+        c = SkyCoord(ra=360.625*u.degree, dec=70.2*u.degree, frame='icrs')
+        assert c.ra.degree == 0.625
+
+        c = SkyCoord(ra=-0.625*u.degree, dec=71.2*u.degree, frame='icrs')
+        assert c.ra.degree == 359.375
+
+
+    def test_observation_request_init(self, req):
+        c = SkyCoord(ra=10.625*u.degree, dec=41.2*u.degree, frame='icrs')
+        observation_id = 69
+        coordinates = c
+        agency_id = 2
+        priority = 8
+        remaining_observing_chances = 3
+        observation_duration = 6000
+        # req = observation_request.ObservationRequest(observation_id, coordinates,\
+            # agency_id,priority, remaining_observing_chances, observation_duration)
+        assert hasattr(req, 'observation_id')
+        assert hasattr(req, 'coordinates')
+        assert hasattr(req, 'agency_id')
+        assert hasattr(req, 'priority')
+        assert hasattr(req, 'remaining_observing_chances')
+        assert hasattr(req, 'observation_duration')
+
+
+    def test_observation_request_get_target(self, req):
+        target = req.get_target()
+        assert isinstance(target, FixedTarget)
+
+    def test_observation_request_to_string(self, req):
+        assert str(req) == "69 10.625 41.2 2 8"


### PR DESCRIPTION
- General tests for transformer.py in data_importer.
- general tests for observation_request in observation.

The way a fixedTarget was being created had an issue with accessing the ra and dec of a skycoord object. This was fixed and can be accessed with skycoordobject.ra.degree for future reference.