### PR TITLE
first step towards having scheduler consume real request objects and …

### DIFF
--- a/src/tso/observation/observation_request.py
+++ b/src/tso/observation/observation_request.py
@@ -2,22 +2,21 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord, Angle
 from astroplan import FixedTarget
 
+# TODO: Confirm if this takes coordinates as a tuple of floats or as an already-instantiated SKyCoord object
+# ^ SkyCoord is imported but not used
 
 class ObservationRequest:
 
     def __init__(
-        self, observation_id, coordinates, agency_id, priority, remaining_observing_chances, observation_duration
+        self, observation_id, coordinates, agency_id, priority, remaining_observing_chances, duration
     ):
         self.observation_id = observation_id
         self.coordinates = coordinates
         self.agency_id = agency_id
         self.priority = priority
         self.remaining_observing_chances = remaining_observing_chances
-        self.observation_duration = observation_duration
-
-    def get_target(self):
-        target = FixedTarget(coord=self.coordinates, name=str(self.observation_id))
-        return target
+        self.duration = duration
+        self.target = FixedTarget(coord=coordinates, name=str(observation_id))
 
     def __str__(self):
         return str(self.observation_id) + " " + \

--- a/src/tso/observation/tests/test_observation_request.py
+++ b/src/tso/observation/tests/test_observation_request.py
@@ -54,10 +54,12 @@ class TestObservationRequest():
         assert hasattr(req, 'priority')
         assert hasattr(req, 'remaining_observing_chances')
         assert hasattr(req, 'observation_duration')
+        assert hasattr(req, 'target')
+
 
 
     def test_observation_request_get_target(self, req):
-        target = req.get_target()
+        target = req.target
         assert isinstance(target, FixedTarget)
 
     def test_observation_request_to_string(self, req):

--- a/src/tso/scheduler/__main__.py
+++ b/src/tso/scheduler/__main__.py
@@ -1,4 +1,6 @@
 from tso.scheduler import scheduler
+from tso.scheduler.utils import generate_requests as gr
+from tso.exporter import exporter
 
 config = {
     'slew_rate': 0.8,
@@ -7,14 +9,17 @@ config = {
     }
 }
 
+N_BLOCKS = 5
+
 def main():
     print('Inside the main Scheduler Application')
 
+    requests = gr.generate_requests(N_BLOCKS)
     start_datetime = '2019-03-01 19:00'
     end_datetime = '2019-03-13 19:00'
-    scheduler.generate_schedule(config, start_datetime, end_datetime)
-
-
+    schedule = scheduler.generate_schedule(config, start_datetime, end_datetime, requests)
+    print(requests[0].target)
+    # exporter.export_to_console(schedule)
 
 if __name__ == '__main__':
     main()

--- a/src/tso/scheduler/scheduler.py
+++ b/src/tso/scheduler/scheduler.py
@@ -20,9 +20,7 @@ def create_transitioner(slew_rate, filters):
     return Transitioner(slew_rate, filters)
 
 
-def generate_schedule(config, start_datetime, end_datetime, ):
-
-    print('Inside scheduler.py')
+def generate_schedule(config, start_datetime, end_datetime, requests):
 
     # Sometimes a warning arises called OldEarthOrientationDataWarning which means the following line must run to refresh
     # we should find a way to catch this warning and only download when necessary
@@ -31,21 +29,8 @@ def generate_schedule(config, start_datetime, end_datetime, ):
     cfht = Observer.at_site('cfht')
     transitioner = create_transitioner(config['slew_rate'], config['filters'])
 
-    # Placeholder -- generating demonstration targets
-    n_targets_test = 30
-    target_names = ['Deneb', 'M13', 'sirius', 'M31', 'Polaris', 'Vega']
-    targets = []
-
-    # dynamically produce a list of FixedTarget objects from the target_names identifiers
-    # This is just a placeholder until we figure out properly creating targets from coords
-
-    for i in range(0,n_targets_test):
-        targets.append(FixedTarget.from_name(target_names[random.randrange(len(target_names))]))
-
     # Retrieve global constraints from Constraint Aggregator
     global_constraints = ca.initialize_constraints()
-
-    # requests = di.get_observations_with_constraint(min_priority=99)
 
     # These are hard
     read_out = 20 * u.second
@@ -56,9 +41,9 @@ def generate_schedule(config, start_datetime, end_datetime, ):
     # Hardcoded test constraints -- may have some on the ObservingBlock level
     # These differ from global_constraints above which are applied to all observations in the schedule
 
-    half_night_start = Time('2019-03-12 02:00')
-    half_night_end = Time('2019-03-12 08:00')
-    first_half_night = TimeConstraint(half_night_start, half_night_end)
+    # half_night_start = Time('2019-03-12 02:00')
+    # half_night_end = Time('2019-03-12 08:00')
+    # first_half_night = TimeConstraint(half_night_start, half_night_end)
 
     # for request in requests:
 
@@ -73,30 +58,19 @@ def generate_schedule(config, start_datetime, end_datetime, ):
 
     #     blocks.append(block)
 
-    deneb_exp = 100 * u.second
-    m13_exp = 50 * u.second
+    # deneb_exp = 100 * u.second
+    # m13_exp = 50 * u.second
 
-    for target in targets:
-        for priority, bandpass in enumerate(['MSE']):
-            block = ObservingBlock.from_exposures(target, priority, deneb_exp, n_exp, read_out,
+    for request in requests:
+        for bandpass in ['MSE']:
+            block = ObservingBlock.from_exposures(request.target, request.priority, request.duration, n_exp, read_out,
                                             configuration={'filter': bandpass},
                                             constraints=[])
             blocks.append(block)
-            print('Appending block with Target {} and filter {}'.format(target, bandpass))
+            print('Appending block with Target {} and filter {}'.format(request.target, bandpass))
 
-    # for priority, bandpass in enumerate(['B', 'G', 'R']):
-    #     # We want each filter to have separate priority (so that target
-    #     # and reference are both scheduled)
-    #     b = ObservingBlock.from_exposures(deneb, priority, deneb_exp, n_exp, read_out,
-    #                                       configuration={'filter': bandpass},
-    #                                       constraints=[])
-    #     blocks.append(b)
-    #     b = ObservingBlock.from_exposures(m13, priority, m13_exp, n_exp, read_out,
-    #                                       configuration={'filter': bandpass},
-    #                                       constraints=[])
-    #     blocks.append(b)
 
-    prior_scheduler = SequentialScheduler(constraints=global_constraints,
+    prior_scheduler = PriorityScheduler(constraints=global_constraints,
                                           observer=cfht,
                                           transitioner=transitioner)
 

--- a/src/tso/scheduler/tests/test_scheduler.py
+++ b/src/tso/scheduler/tests/test_scheduler.py
@@ -2,9 +2,17 @@
 
 import pytest
 from tso.scheduler import scheduler
+from tso.scheduler.utils import generate_requests as gr
+from astroplan.scheduling import Schedule
 
-OBSERVATION_BLOCKS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+N_BLOCKS = 10
 
+testSchedulerConfig = {
+    'slew_rate': 0.8,
+    'filters': {
+        'filter': {('MSE', 'EXAMPLE'): 10 }
+    }
+}
 
 def pytest_generate_tests(metafunc):
     # called once per each test function
@@ -13,14 +21,12 @@ def pytest_generate_tests(metafunc):
     metafunc.parametrize(argnames, [[funcargs[name] for name in argnames]
                                     for funcargs in funcarglist])
 
-
 class TestScheduler(object):
 
     params = {
-        'test_generate_schedule': [dict(timeslots=1000, pop=1000, gen=10, cxpb=0.5, mutpb=0.2, blocks=OBSERVATION_BLOCKS), ]
+        'test_generate_schedule': [dict(start_datetime='2019-03-10 19:00', end_datetime='2019-03-12 19:00', requests=gr.generate_requests(N_BLOCKS)), ]
     }
 
-    def test_generate_schedule(self, timeslots, pop, gen, cxpb, mutpb, blocks):
-        optimal_ind = op_sched.optimize_schedule(
-            timeslots, pop, gen, cxpb, mutpb, blocks)
-        assert isinstance(optimal_ind, list)
+    def test_generate_schedule(self, start_datetime, end_datetime, requests):
+        schedule = scheduler.generate_schedule(testSchedulerConfig, start_datetime, end_datetime, requests)
+        assert isinstance(schedule, Schedule)

--- a/src/tso/scheduler/utils/generate_requests.py
+++ b/src/tso/scheduler/utils/generate_requests.py
@@ -1,0 +1,20 @@
+from tso.observation.observation_request import ObservationRequest
+from astropy.coordinates import SkyCoord, Angle
+from astropy import units as u
+import random
+
+def generate_requests(n_requests):
+    reqs = []
+    for i in range(n_requests):
+        # Build a request and append to reqs list
+        obs_id = i
+        coordinates = SkyCoord(ra=250.0*u.deg, dec=-16.0*u.deg)
+        agency_id = 1
+        priority = i
+        remaining_chances = 1
+        duration = 60.0 * u.second
+        req = ObservationRequest(obs_id, coordinates, agency_id, priority, remaining_chances, duration)
+
+        reqs.append(req)
+
+    return reqs


### PR DESCRIPTION
…forming targets from coordinates

# Notes

- Scheduling has been successful so far using SkyCoord objects see `generate_requests.py` for how I'm making the requests
- This includes a slight change to the `ObservationRequest` object to just set the target attr right away based on the given coordinates
- The instantiation of the coordinates may change as the scheduler is working properly it seems but there is a bug in the `to_table()` method where it cannot effectively handle certain coordinate types. There is a TODO in the source code for the method but we'll probably need to just work around it for now